### PR TITLE
add deno, netlify, edgeone deployment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,46 @@ Vercel 部署的优点是简单快速，支持自动更新，并且默认提供 
    - `PREFIX`（例如：`public`）
    - `SECRET_TOKEN`（必须包含大小写字母和数字，长度至少16位）
 
+#### 方法五：Deno 一键部署
+
+Deno 提供了另一种简单的部署方式，也支持从 GitHub 仓库自动部署。
+
+1. Fork 本仓库到您的 GitHub 账户
+2. 登录 [Deno Deploy](https://dash.deno.com) 并点击 **New Project**
+3. 选择已授权的 GitHub 账户并选择您的 Fork 仓库
+4. 在 **Project Configuration** -> **Entrypoint** 下选择 `deno/server.js`
+5. 点击 **Deploy Project** 按钮，等待部署完成
+6. 点击页面底部 **Add environment variables** 按钮，添加环境变量：
+   - `PREFIX`：URL前缀，例如 `public`
+   - `SECRET_TOKEN`：加密令牌，必须包含大小写字母和数字，长度至少16位
+7. 点击 **Save (2 new)** 按钮保存环境变量后即完成部署，环境变量上方即为 Deno 提供的域名，如 `project-name.deno.dev`
+
+#### 方法六：Netlify 一键部署
+
+Netlify 提供了另一种简单的部署方式，也支持从 GitHub 仓库自动部署。
+
+1. Fork 本仓库到您的 GitHub 账户
+2. 登录 [Netlify](https://app.netlify.com/) 并点击 **Add new site** -> **Add new site
+Import an existing project**
+3. 选择已授权的 GitHub 账户并选择您的 Fork 仓库
+4. 填写 **Site name** 并添加环境变量：
+   - 点击 **Add environment variables** -> **Add key/value pairs**
+   - `NETLIFY_PREFIX`：URL前缀，例如 `public`
+   - `SECRET_TOKEN`：加密令牌，必须包含大小写字母和数字，长度至少16位
+5. 点击 **Deploy xxx** 按钮，部署完成后即可在站点名称下看到 Netlify 提供的域名，如 `site-name.netlify.app`
+
+#### 方法七：EdgeOne 一键部署
+
+EdgeOne 提供了另一种简单的部署方式，也支持从 GitHub 仓库自动部署。
+
+1. Fork 本仓库到您的 GitHub 账户
+2. 登录 [EdgeOne Pages](https://edgeone.ai/login?s_url=https://console.tencentcloud.com/edgeone/pages) 并点击 **创建项目** -> **导入 Git 仓库**
+3. 选择已授权的 GitHub 账户并选择您的 Fork 仓库
+4. 添加环境变量：
+   - `EDGEONE_PREFIX`：URL前缀，例如 `public`
+   - `SECRET_TOKEN`：加密令牌，必须包含大小写字母和数字，长度至少16位
+5. 点击 **开始部署** 按钮，部署完成后转到 **项目设置** -> **域名管理** 添加自定义域名，默认域名 `project-name.edgeone.app` 只支持预览，有效期仅 3 个小时！
+
 ### 3.1 (可选) 绑定自定义域名 🌐
 
 > [!TIP]
@@ -142,6 +182,9 @@ Cloudflare 允许您将自己的域名绑定到 Worker 上，这样您就可以�
 - GitHub 集成：`https://your-project-name.username.workers.dev`
 - Vercel 部署：`https://your-project.vercel.app`
 - Wrangler/Dashboard：`https://your-worker-name.your-subdomain.workers.dev`
+- Deno 部署：`https://project-name.deno.dev`
+- Netlify 部署：`https://site-name.netlify.app`
+- EdgeOne 部署：`https://your.custom.domain`
 
 现在您需要注册您的 Bot：
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -121,6 +121,45 @@ If you prefer not to use GitHub or command-line tools, you can create the Worker
    - `PREFIX` (e.g., `public`)
    - `SECRET_TOKEN` (must contain uppercase and lowercase letters and numbers, at least 16 characters long)
 
+#### Method 5: Deno One-Click Deployment
+
+Deno provides another simple deployment method, which also supports automatic deployment from GitHub repositories.
+
+1. Fork this repository to your GitHub account
+2. Log in to [Deno Deploy](https://dash.deno.com) and click **New Project**
+3. Select your authorized GitHub account and choose your forked repository
+4. Under **Project Configuration** -> **Entrypoint**, select `deno/server.js`
+5. Click the **Deploy Project** button and wait for the deployment to complete
+6. Click the **Add environment variables** button at the bottom of the page to add environment variables:
+   - `PREFIX`: URL prefix, for example `public`
+   - `SECRET_TOKEN`: Encryption token, must include uppercase and lowercase letters and numbers, with a minimum length of 16 characters
+7. After clicking the **Save (2 new)** button to save the environment variables, the deployment is complete. The domain name provided by Deno is above the environment variables, such as `project-name.deno.dev`
+
+#### Method 6: Netlify One-Click Deployment
+
+Netlify provides another simple deployment method, which also supports automatic deployment from GitHub repositories.
+
+1. Fork this repository to your GitHub account
+2. Log in to [Netlify](https://app.netlify.com/) and click **Add new site** -> **Add new site** -> **Import an existing project**
+3. Select your authorized GitHub account and choose your forked repository
+4. Fill in the **Site name** and add environment variables:
+   - Click **Add environment variables** -> **Add key/value pairs**
+   - `NETLIFY_PREFIX`: URL prefix, for example `public`
+   - `SECRET_TOKEN`: Encryption token, must include uppercase and lowercase letters and numbers, with a minimum length of 16 characters
+5. Click the **Deploy xxx** button, and after the deployment is complete, you can see the Netlify-provided domain name under the site name, such as `site-name.netlify.app`
+
+#### Method 7: EdgeOne One-Click Deployment
+
+EdgeOne provides another simple deployment method, which also supports automatic deployment from GitHub repositories.
+
+1. Fork this repository to your GitHub account
+2. Log in to [EdgeOne Pages](https://edgeone.ai/login?s_url=https://console.tencentcloud.com/edgeone/pages) and click **Create Project** -> **Import Git Repository**
+3. Select the authorized GitHub account and choose your forked repository
+4. Add environment variables:
+- `EDGEONE_PREFIX`: URL prefix, for example `public`
+- `SECRET_TOKEN`: Encryption token, must include uppercase and lowercase letters and numbers, with a minimum length of 16 characters
+5. Click the **Start Deployment** button, and after the deployment is complete, go to **Project Settings** -> **Domain Management** to add a custom domain. The default domain `project-name.edgeone.app` only supports preview, and its validity period is only 3 hours!
+
 ### 3.1 (Optional) Bind a Custom Domain 🌐
 
 > [!TIP]
@@ -141,6 +180,9 @@ After deploying the Worker, you'll get a URL like:
 - GitHub integration: `https://your-project-name.username.workers.dev`
 - Vercel deployment: `https://your-project.vercel.app`
 - Wrangler/Dashboard: `https://your-worker-name.your-subdomain.workers.dev`
+- Deno deployment: `https://project-name.deno.dev`
+- Netlify deployment: `https://site-name.netlify.app`
+- EdgeOne deployment: `https://your.custom.domain`
 
 Now you need to register your Bot:
 

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,5 @@
+{
+  "deploy": {
+    "entrypoint": "deno/server.js"
+  }
+}

--- a/deno/server.js
+++ b/deno/server.js
@@ -1,0 +1,32 @@
+/**
+ * Open Wegram Bot - Deno Entry Point
+ * A two-way private messaging Telegram bot
+ *
+ * GitHub Repository: https://github.com/wozulong/open-wegram-bot
+ */
+
+import {handleRequest} from "../src/core.js";
+
+Deno.serve(async (req) => {
+    const request = new Request(req.url, {
+        method: req.method,
+        headers: new Headers(req.headers),
+        body: req.method !== "GET" && req.method !== "HEAD" ? await req.text() : null
+    });
+
+    const config = {
+        prefix: Deno.env.get("PREFIX") || "public",
+        secretToken: Deno.env.get("SECRET_TOKEN") || ""
+    };
+
+    const response = await handleRequest(request, config);
+
+    const body = await response.text();
+
+    return new Response(body, {
+        status: response.status,
+        headers: {
+            "Content-Type": response.headers.get("Content-Type") || "text/plain",
+        },
+    });
+});

--- a/edgeone.json
+++ b/edgeone.json
@@ -1,0 +1,7 @@
+{
+    "name": "open-wegram-bot",
+    "buildCommand": "rm -f package-lock.json",
+    "installCommand": "echo 'no install'",
+    "outputDirectory": "./",
+    "nodeVersion": "22.11.0"
+}

--- a/functions/[[index]].js
+++ b/functions/[[index]].js
@@ -1,0 +1,33 @@
+/**
+ * Open Wegram Bot - EdgeOne Entry Point
+ * A two-way private messaging Telegram bot
+ *
+ * GitHub Repository: https://github.com/wozulong/open-wegram-bot
+ */
+
+import {handleRequest} from '../src/core.js';
+
+export default async function onRequest(context) {
+    const req = context.request;
+    const request = new Request(req.url, {
+        method: req.method,
+        headers: new Headers(req.headers),
+        body: req.method !== 'GET' && req.method !== 'HEAD' ? await req.text() : null
+    });
+
+    const config = {
+        prefix: context.env.EDGEONE_PREFIX || 'public',
+        secretToken: context.env.SECRET_TOKEN || ''
+    };
+
+    const response = await handleRequest(request, config);
+
+    const body = await response.text();
+
+    return new Response(body, {
+        status: response.status,
+        headers: {
+            'Content-Type': response.headers.get('Content-Type') || 'text/plain',
+        },
+    });
+}

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[[edge_functions]]
+  path = "/*"
+  function = "server"

--- a/netlify/edge-functions/server.js
+++ b/netlify/edge-functions/server.js
@@ -1,0 +1,32 @@
+/**
+ * Open Wegram Bot - Netlify Entry Point
+ * A two-way private messaging Telegram bot
+ *
+ * GitHub Repository: https://github.com/wozulong/open-wegram-bot
+ */
+
+import {handleRequest} from "../../src/core.js";
+
+export default async (req) => {
+    const request = new Request(req.url, {
+        method: req.method,
+        headers: new Headers(req.headers),
+        body: req.method !== "GET" && req.method !== "HEAD" ? await req.text() : null
+    });
+
+    const config = {
+        prefix: Netlify.env.get("NETLIFY_PREFIX") || "public",
+        secretToken: Netlify.env.get("SECRET_TOKEN") || ""
+    };
+
+    const response = await handleRequest(request, config);
+
+    const body = await response.text();
+
+    return new Response(body, {
+        status: response.status,
+        headers: {
+            "Content-Type": response.headers.get("Content-Type") || "text/plain",
+        },
+    });
+};


### PR DESCRIPTION
- 增加 [Deno](https://deno.com) 部署入口，免费额度100万/月，部署 Demo : `https://owb.deno.dev/public/`
- 增加 [Netlify](https://www.netlify.com) 部署入口，免费额度100万/月，部署 Demo : `https://owgb.netlify.app/public/`
- 增加 [EdgeOne](https://edgeone.ai/products/pages) 部署入口，公测期间暂无限制，正式版有免费额度（具体暂不知），部署 Demo : `https://owb.com.mp/public/`

以上部署测试各项功能均正常，中英文README均已更新。